### PR TITLE
Maked world better

### DIFF
--- a/Content.Shared/Roles/JobRequirement/PronounMatchesSexRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/PronounMatchesSexRequirement.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Preferences;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+using Content.Shared.Humanoid;
+
+namespace Content.Shared._Slon.Roles;
+
+/// <summary>
+/// Requires that the selected pronouns (Gender) match the character's Sex.
+/// - Sex.Male   -> Gender.Male (he/him)
+/// - Sex.Female -> Gender.Female (she/her)
+/// Any other combinations (including Epicene/Neuter) are not allowed.
+/// </summary>
+[UsedImplicitly]
+[Serializable, NetSerializable]
+public sealed partial class PronounMatchesSexRequirement : JobRequirement
+{
+    public override bool Check(IEntityManager entManager,
+        IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = null;
+
+        if (profile is null)
+            return true;
+
+        var sex = profile.Sex;
+        var gender = profile.Gender;
+
+        var allowed = (sex == Sex.Male && gender == Gender.Male)
+                   || (sex == Sex.Female && gender == Gender.Female);
+
+        if (allowed)
+            return true;
+
+        reason = FormattedMessage.FromMarkupPermissive(
+            Loc.GetString("role-requirements-pronouns-mismatch"));
+        return false;
+    }
+}
+
+

--- a/Content.Shared/Roles/JobRequirement/SkinToneRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/SkinToneRequirement.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Humanoid;
+using Content.Shared.Preferences;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._Slon.Roles;
+
+/// <summary>
+/// Requires the character's human skin tone to be less than or equal to a configured threshold (0-100).
+/// See <see cref="SkinColor.HumanSkinToneFromColor"/> for mapping details.
+/// </summary>
+[UsedImplicitly]
+[Serializable, NetSerializable]
+public sealed partial class SkinToneRequirement : JobRequirement
+{
+    /// <summary>
+    /// Maximum allowed human skin tone value (0-100).
+    /// </summary>
+    [DataField(required: true)]
+    public int MaxHumanSkinTone { get; set; }
+
+    public override bool Check(IEntityManager entManager,
+        IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = null;
+
+        if (profile is null)
+            return true;
+
+        var tone = SkinColor.HumanSkinToneFromColor(profile.Appearance.SkinColor);
+
+        var failed = Inverted
+            ? tone <= MaxHumanSkinTone
+            : tone > MaxHumanSkinTone;
+
+        if (!failed)
+            return true;
+
+        var message = Inverted
+            ? Loc.GetString("role-requirements-skin-tone-inverted", ("tone", MaxHumanSkinTone))
+            : Loc.GetString("role-requirements-skin-tone", ("tone", MaxHumanSkinTone));
+
+        reason = FormattedMessage.FromMarkupPermissive(message);
+        return false;
+    }
+}
+
+

--- a/Resources/Locale/en-US/job/role-requirements.ftl
+++ b/Resources/Locale/en-US/job/role-requirements.ftl
@@ -25,6 +25,11 @@ role-timer-blacklisted-species = Your character must not be one of the following
 role-timer-whitelisted-traits = Your character must have one of the following traits for you to select this:
 role-timer-blacklisted-traits = Your character must not have any of the following traits for you to select this:
 
+# Additional requirement messages
+role-requirements-pronouns-mismatch = Your pronouns do not match your selected sex.
+role-requirements-skin-tone = Your skin tone must be at or below [color=yellow]{$tone}%[/color] for this role.
+role-requirements-skin-tone-inverted = Your skin tone must be above [color=yellow]{$tone}%[/color] for this role.
+
 role-timer-locked = Locked (hover for details)
 
 role-timer-department-unknown = Unknown Department

--- a/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
@@ -44,6 +44,9 @@
   requirements:
   - !type:AgeRequirement
     requiredAge: 21
+  - !type:PronounMatchesSexRequirement
+  - !type:SkinToneRequirement
+    maxHumanSkinTone: 80
   accessGroups:
   - AllAccess
   access:

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -154,6 +154,9 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 14400 # 4 hours
+    - !type:PronounMatchesSexRequirement
+    - !type:SkinToneRequirement
+      maxHumanSkinTone: 80
       #any MRP using our code might eventually want to use it
     # - !type:SaturationRequirement # MisandryBox - no neon hair on captain
     #   hairColorSaturation: 0.30

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -152,6 +152,9 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 9000 # 2.5 hours
+    - !type:PronounMatchesSexRequirement
+    - !type:SkinToneRequirement
+      maxHumanSkinTone: 80
   goobcoins: 40 #Goob content
   weight: 20
   startingGear: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -143,6 +143,9 @@
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 36000 #10 hrs
+    - !type:PronounMatchesSexRequirement
+    - !type:SkinToneRequirement
+      maxHumanSkinTone: 80
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -145,6 +145,9 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 36000 #10 hrs
+    - !type:PronounMatchesSexRequirement
+    - !type:SkinToneRequirement
+      maxHumanSkinTone: 80
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -143,6 +143,9 @@
   - !type:DepartmentTimeRequirement
     department: Science
     time: 36000 #10 hrs
+  - !type:PronounMatchesSexRequirement
+  - !type:SkinToneRequirement
+    maxHumanSkinTone: 80
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -151,6 +151,9 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 # 10 hrs
+    - !type:PronounMatchesSexRequirement
+    - !type:SkinToneRequirement
+      maxHumanSkinTone: 80
   #  - !type:StyleRequirement
   #    styles:
   #    - HumanHairFloorlengthBedhead

--- a/Resources/Prototypes/Rules/placeholder.txt
+++ b/Resources/Prototypes/Rules/placeholder.txt
@@ -1,0 +1,2 @@
+placeholder
+

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/blueshield_officer.yml
@@ -45,6 +45,9 @@
       time: 90000 # 25 hours
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:PronounMatchesSexRequirement
+    - !type:SkinToneRequirement
+      maxHumanSkinTone: 80
   goobcoins: 45
   weight: 20
   startingGear: BlueshieldOfficerGear

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
@@ -102,6 +102,9 @@
       time: 180000  #50 hours
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:PronounMatchesSexRequirement
+    - !type:SkinToneRequirement
+      maxHumanSkinTone: 80
   weight: 20
   startingGear: NanotrasenRepresentativeGear
   icon: "JobIconNanotrasenRepresentative"


### PR DESCRIPTION
## About the PR
Added a job requirement for command and centcomm roles, they cannot anymore have pronounces that unmatch their gender, they also cannot have too dark skin


## Why/Balance

Cool

## Media
no

## Requirements

- [x] I have read and followed the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.



## Changelog

:cl:
- add: Added a job requirement for command and cc roles, they cannot anymore have pronounces that unmatch their gender, they also cannot have too dark skin
:cl: